### PR TITLE
Modify Mirai.receiver()

### DIFF
--- a/mirai/application.py
+++ b/mirai/application.py
@@ -128,6 +128,7 @@ class Mirai(MiraiProtocol):
       dependencies: List[Depend] = None,
       use_middlewares: List[Callable] = None
     ):
+    event_name = self.getEventCurrentName(event_name)
     def receiver_warpper(func: Callable):
       if not inspect.iscoroutinefunction(func):
         raise TypeError("event body must be a coroutine function.")


### PR DESCRIPTION
reciever()接受Annotation参数时应获取其名称，Mirai.event事件表中的键应为str类型，而非class