### PR TITLE
fix json

### DIFF
--- a/mirai/event/message/components.py
+++ b/mirai/event/message/components.py
@@ -176,10 +176,10 @@ class Xml(BaseMessageComponent):
 
 class Json(BaseMessageComponent):
     type: MessageComponentTypes = "Json"
-    Json: dict = Field(..., alias="json")
+    Json: str = Field(..., alias="json")
 
-    def __init__(self, json: dict, **_):
-        super().__init__(Json=json)
+    def __init__(self, json: str, **_):
+        super().__init__(json=json)
 
 class App(BaseMessageComponent):
     type: MessageComponentTypes = "App"

--- a/mirai/protocol.py
+++ b/mirai/protocol.py
@@ -348,7 +348,7 @@ class MiraiProtocol:
                 "sessionKey": self.session_key,
                 "target": self.handleTargetAsGroup(group),
                 "memberId": self.handleTargetAsMember(member),
-                "info": json.loads(setting.json())
+                "info": json.loads(setting.json(by_alias=True))
             }
         ), raise_exception=True)
 
@@ -374,7 +374,7 @@ class MiraiProtocol:
             await fetch.http_post(f"{self.baseurl}/groupConfig", {
                 "sessionKey": self.session_key,
                 "target": self.handleTargetAsGroup(group),
-                "config": json.loads(config.json())
+                "config": json.loads(config.json(by_alias=True))
             }
         ), raise_exception=True)
 
@@ -497,9 +497,9 @@ class MiraiProtocol:
             str
         ]):
         if isinstance(message, MessageChain):
-            return json.loads(message.json())
+            return json.loads(message.json(by_alias=True))
         elif isinstance(message, BaseMessageComponent):
-            return [json.loads(message.json())]
+            return [json.loads(message.json(by_alias=True))]
         elif isinstance(message, (tuple, list)):
             result = []
             for i in message:
@@ -519,10 +519,10 @@ class MiraiProtocol:
                         "imageId": i.asGroupImage()
                     })
                 else:
-                    result.append(json.loads(i.json()))
+                    result.append(json.loads(i.json(by_alias=True)))
             return result
         elif isinstance(message, str):
-            return [json.loads(components.Plain(text=message).json())]
+            return [json.loads(components.Plain(text=message).json(by_alias=True))]
         else:
             raise raiser(ValueError("invaild message."))
 
@@ -535,9 +535,9 @@ class MiraiProtocol:
             str
         ]):
         if isinstance(message, MessageChain):
-            return json.loads(message.json())
+            return json.loads(message.json(by_alias=True))
         elif isinstance(message, BaseMessageComponent):
-            return [json.loads(message.json())]
+            return [json.loads(message.json(by_alias=True))]
         elif isinstance(message, (tuple, list)):
             result = []
             for i in message:
@@ -552,10 +552,10 @@ class MiraiProtocol:
                         "imageId": i.asFriendImage()
                     })
                 else:
-                    result.append(json.loads(i.json()))
+                    result.append(json.loads(i.json(by_alias=True)))
             return result
         elif isinstance(message, str):
-            return [json.loads(components.Plain(text=message).json())]
+            return [json.loads(components.Plain(text=message).json(by_alias=True))]
         else:
             raise raiser(ValueError("invaild message."))
 
@@ -568,9 +568,9 @@ class MiraiProtocol:
             str
         ]):
         if isinstance(message, MessageChain):
-            return json.loads(message.json())
+            return json.loads(message.json(by_alias=True))
         elif isinstance(message, BaseMessageComponent):
-            return [json.loads(message.json())]
+            return [json.loads(message.json(by_alias=True))]
         elif isinstance(message, (tuple, list)):
             result = []
             for i in message:
@@ -585,10 +585,10 @@ class MiraiProtocol:
                         "imageId": i.asFriendImage()
                     })
                 else:
-                    result.append(json.loads(i.json()))
+                    result.append(json.loads(i.json(by_alias=True)))
             return result
         elif isinstance(message, str):
-            return [json.loads(components.Plain(text=message).json())]
+            return [json.loads(components.Plain(text=message).json(by_alias=True))]
         else:
             raise raiser(ValueError("invaild message."))
 


### PR DESCRIPTION
上游http-api反馈json需要是字符串形式才能正确发送，另外如果不设置by_alias=True，json序列化的时候不会把alias作为键名，需要加上。